### PR TITLE
[test] read uncommitted 격리레벨 테스트 추가

### DIFF
--- a/src/main/java/com/test/learningtx/service/AccountService.java
+++ b/src/main/java/com/test/learningtx/service/AccountService.java
@@ -5,6 +5,7 @@ import com.test.learningtx.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -35,7 +36,16 @@ public class AccountService {
 //                String.format("Transfer %d from %s to %s", amount, fromAccount, toAccount));
 
         log.info("=== 계좌 이체 완료 ===");
-        
+    }
 
+    // READ_UNCOMMITTED: 가장 낮은 격리 레벨
+    //  - Dirty Read 가능 (커밋x 데이터 읽기)
+    //  - 성능은 가장 좋지만 데이터 일관성 문제 발생 가능
+    //  - A 트랜잭션이 데이터 변경 (아직 커밋 X) -> B 트랜잭션이 A가 변경한 데이터 읽음 -> A 트랜잭션 롤백 -> B가 읽은 데이터는 유령 데이터가 됨
+    @Transactional(isolation = Isolation.READ_UNCOMMITTED)
+    public Account readUncommitted(Long accountId) {
+        log.info("=== READ_UNCOMMITTED로 계좌 조회: {} ===", accountId);
+        return accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("계좌를 찾을 수 없음"));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,10 +20,10 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
 
   logging:
     level:
       org.springframework.transaction: DEBUG
-      org.hibernate.SQL: DEBUG
-      org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+#      org.hibernate.SQL: DEBUG
+#      org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/src/test/java/com/test/learningtx/BasicTxTest.java
+++ b/src/test/java/com/test/learningtx/BasicTxTest.java
@@ -9,6 +9,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -21,6 +26,9 @@ public class BasicTxTest {
 
     @Autowired
     private AccountRepository accountRepository;
+
+    @Autowired
+    private TestTxService testTxService;
 
     private Account account1;
     private Account account2;
@@ -54,6 +62,59 @@ public class BasicTxTest {
 
         assertEquals(7000L, updatedAccount1.getBalance());
         assertEquals(8000L, updatedAccount2.getBalance());
+    }
+
+    @Test
+    @DisplayName("READ_UNCOMMITTED Dirty Read 테스트")
+    void testDirtyRead() throws Exception {
+        Long accountId = account1.getId();
+        boolean dirtyReadExists = false;
+
+        // when - 동시에 두 작업 실행 5번 반복
+        for (int i=0; i<5; i++) {
+            System.out.println("=== 시도 " + (i+1) + " ===");
+
+            // CompletableFuture: Java에서 비동기 작업을 쉽게 처리할 수 있게 해주는 클래스
+            //  - supplyAsync: 값을 반환하는 비동기 작업
+            CompletableFuture<Account> readTask = CompletableFuture.supplyAsync(() -> {
+                try {
+                    Thread.sleep(50);  // 변경 작업이 시작될 시간 주기
+                    return accountService.readUncommitted(accountId);   // 별도 스레드에서 실행
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+    
+            //  - runAsync: 반환값이 없는 비동기 작업
+            CompletableFuture<Void> updateTask = CompletableFuture.runAsync(() -> {
+                try {
+                    testTxService.updateAndRollback(accountId);
+                } catch (Exception e) {
+                    // 의도적 롤백 예외 무시
+                    System.out.println("예상된 롤백 발생: " + e.getMessage());
+                }
+            });
+    
+            // then
+            Account readResult = readTask.get();    // 결과가 나올 때까지 기다림
+            updateTask.get();
+    
+            System.out.println("READ_UNCOMMITTED로 읽은 잔액: " + readResult.getBalance());
+            System.out.println("실제 최종 잔액: " + accountRepository.findById(accountId).get().getBalance());
+
+            if (!Objects.equals(readResult.getBalance(), accountRepository.findById(accountId).get().getBalance())) {
+                dirtyReadExists = true;
+                System.out.println("Dirty Read 발견!");
+                break;
+            }
+        }
+
+        // 루프 밖에서 검증
+        if (dirtyReadExists) {
+            System.out.println("Dirty Read 테스트 성공");
+        } else {
+            System.out.println("Dirty Read 발생하지 않음 (타이밍 이슈 또는 H2 제한)");
+        }
     }
 
 }

--- a/src/test/java/com/test/learningtx/TestTxService.java
+++ b/src/test/java/com/test/learningtx/TestTxService.java
@@ -1,0 +1,35 @@
+package com.test.learningtx;
+
+import com.test.learningtx.entity.Account;
+import com.test.learningtx.repository.AccountRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TestTxService {
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Transactional
+    void updateAndRollback(Long accountId) {
+        System.out.println("=== updateAndRollback 시작 ===");
+
+        Account beforeAccount = accountRepository.findById(accountId).get();
+        System.out.println("변경 전 잔액: " + beforeAccount.getBalance());
+
+        beforeAccount.setBalance(5000L);
+        accountRepository.saveAndFlush(beforeAccount);  // JPA 1차 캐시 우회하여 DB에 즉시 반영 (아직 커밋 안됨, 롤백 가능)
+        System.out.println("변경 후 잔액: " + beforeAccount.getBalance());
+
+        try {
+            Thread.sleep(500);  // READ_UNCOMMITTED가 읽을 시간 주기
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        System.out.println("롤백 시작!");
+        throw new RuntimeException("의도적 롤백");
+    }
+}


### PR DESCRIPTION
- 동일 클래스 내부 호출 시 @Transactional 미적용 문제 해결을 위해 메서드를 별도 서비스 클래스로 분리