### PR TITLE
[feat] JPA 낙관적 락 동시성 테스트 및 백오프 전략 구현

### DIFF
--- a/src/main/java/com/test/learningtx/entity/OptimisticAccount.java
+++ b/src/main/java/com/test/learningtx/entity/OptimisticAccount.java
@@ -1,0 +1,70 @@
+package com.test.learningtx.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "optimistic_accounts")
+@Getter @Setter
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class OptimisticAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, precision = 15, scale = 0)
+    private BigDecimal balance;
+
+    /**
+     * 🔓 낙관적 락의 핵심: @Version
+     *
+     * 특징:
+     * 1. 엔티티가 저장될 때 0으로 시작
+     * 2. 엔티티가 수정될 때마다 자동으로 +1 증가
+     * 3. UPDATE 시 WHERE 조건에 자동으로 version 조건 추가
+     * 4. version이 다르면 OptimisticLockException 발생
+     */
+    @Version
+    private Long version;
+
+    /**
+     * 입금 처리
+     */
+    public void deposit(BigDecimal amount) {
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("입금 금액은 0보다 커야 합니다.");
+        }
+        this.balance = this.balance.add(amount);
+        // version은 JPA가 자동으로 처리! 우리가 건드릴 필요 없음
+    }
+
+    /**
+     * 출금 처리
+     */
+    public void withdraw(BigDecimal amount) {
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("출금 금액은 0보다 커야 합니다.");
+        }
+
+        if (balance.compareTo(amount) < 0) {
+            throw new IllegalArgumentException("잔액 부족! 현재 잔액: " + balance);
+        }
+
+        this.balance = this.balance.subtract(amount);
+        // version은 save() 할 때 자동으로 증가
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Account{id=%d, name='%s', balance=%s, version=%d}",
+                id, name, balance, version);
+    }
+}

--- a/src/main/java/com/test/learningtx/repository/OptimisticAccountRepository.java
+++ b/src/main/java/com/test/learningtx/repository/OptimisticAccountRepository.java
@@ -1,0 +1,41 @@
+package com.test.learningtx.repository;
+
+import com.test.learningtx.entity.OptimisticAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 낙관적 락 계좌 레포지토리 - 기본 버전
+ *
+ * @Version이 있는 엔티티는 별도 설정 없이도
+ * 자동으로 낙관적 락 적용!
+ */
+@Repository
+public interface OptimisticAccountRepository extends JpaRepository<OptimisticAccount, Long> {
+    /**
+     * 기본 조회 - @Version에 의한 자동 낙관적 락 적용
+     *
+     * 동작:
+     * 1. SELECT id, name, balance, version FROM optimistic_accounts WHERE id = ?
+     * 2. version 값도 함께 엔티티에 저장됨
+     */
+//    Optional<OptimisticAccount> findById(Long id);    // 기본적으로 자동 생성됨
+
+    /**
+     * 기본 저장 - @Version에 의한 자동 version 관리
+     *
+     * 신규 저장 시:
+     * - INSERT ... version = 0
+     *
+     * 수정 시:
+     * - UPDATE ... SET version = version + 1 WHERE id = ? AND version = ?
+     */
+//    OptimisticAccount save(OptimisticAccount account);    // 기본적으로 자동 생성됨
+
+    /**
+     * 이름으로 계좌 찾기
+     */
+    Optional<OptimisticAccount> findByName(String name);
+}

--- a/src/main/java/com/test/learningtx/service/OptimisticLockService.java
+++ b/src/main/java/com/test/learningtx/service/OptimisticLockService.java
@@ -1,0 +1,101 @@
+package com.test.learningtx.service;
+
+import com.test.learningtx.entity.OptimisticAccount;
+import com.test.learningtx.repository.OptimisticAccountRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Random;
+
+/**
+ * 재시도 전략
+ * - 1. 즉시 재시도
+ * - [적용됨] 2. 백오프 재시도 (권장)
+ *     > 즉시 재시도x. 잠시 대기 후 재시도
+ * - 3. Spring Retry (자동)
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OptimisticLockService {
+
+    private final OptimisticAccountRepository repository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * 재시도 로직이 있는 출금 처리
+     * 낙관적 락은 재시도 시 동시성이 높을수록 충돌 확률 증가
+     */
+    @Transactional
+    public void wirhdrawWithRetry(Long accountId, BigDecimal amount) {
+        int maxRetries = 5;  // 최대 5번 시도
+        int attempt = 0;
+
+        while (attempt < maxRetries) {
+            try {
+                attempt++;
+                log.info("🔄 출금 시도 {}/{}: 계좌={}, 금액={}", attempt, maxRetries, accountId, amount);
+
+                // 1. 계좌 조회 (version 포함)
+                OptimisticAccount account = repository.findById(accountId)
+                        .orElseThrow(() -> new IllegalArgumentException("계좌 없음: " + accountId));
+
+                entityManager.refresh(account);  // 강제로 최신 DB 데이터 조회 -> 1차 캐싱으로 인한 재시도 실패 방지
+                log.info("📖 조회된 계좌: 잔액={}, version={}", account.getBalance(), account.getVersion());
+
+                // 2. 비즈니스 로직 실행
+                account.withdraw(amount);
+
+                // 3. 저장 (여기서 OptimisticLockingFailureException 발생 가능)
+                OptimisticAccount saved = repository.saveAndFlush(account);
+
+                log.info("✅ 출금 성공! 최종 잔액={}, version={}", saved.getBalance(), saved.getVersion());
+                return; // 성공하면 메서드 종료
+
+            } catch (OptimisticLockingFailureException e) {
+                log.warn("⚠️ 낙관적 락 충돌 발생! 시도 {}/{}", attempt, maxRetries);
+
+                if (attempt >= maxRetries) {
+                    log.error("❌ 최대 재시도 횟수 초과! 출금 실패");
+                    throw new RuntimeException("출금 처리 실패: 너무 많은 동시 접근", e);
+                }
+
+                // 백오프 전략: 점진적으로 대기 시간 증가
+                // 시간이 짧을 수록 동시성 높음 -> 충돌 발생
+                // 🔑 핵심 2: 재시도할 때도 랜덤 지연으로 분산
+                try {
+                    int retryDelay = 100 + new Random().nextInt(300); // 100~399ms 랜덤
+                    System.out.printf("⏰ [%s] %dms 랜덤 대기%n", Thread.currentThread().getName(), retryDelay);
+                    Thread.sleep(retryDelay);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("대기 중 인터럽트: " + Thread.currentThread().getName(), ie);
+                }
+            }
+        }
+    }
+
+    /**
+     * 재시도 없는 출금 (비교용)
+     */
+    @Transactional
+    public void withdrawNoRetry(Long accountId, BigDecimal amount) {
+        log.info("🚫 재시도 없는 출금: 계좌={}, 금액={}", accountId, amount);
+
+        OptimisticAccount account = repository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("계좌 없음: " + accountId));
+
+        account.withdraw(amount);
+        repository.save(account); // 실패하면 그냥 예외 발생
+
+        log.info("✅ 출금 성공 (재시도 없음)");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,11 @@
-spring:
+server:
   port: 18080
+
+spring:
   application:
     name: learning-tx
-  active:
-    profiles: dev
+  profiles:
+    active: dev
 
   # H2 Database 설정 (개발/테스트용)
   datasource:
@@ -30,11 +32,14 @@ spring:
       hibernate:
         format_sql: false
 
-  # 로깅 설정
-  logging:
-    level:
-      root: INFO
-      org.hibernate.SQL: DEBUG
-      org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-      org.springframework.orm.jpa: DEBUG
-      org.springframework.transaction: DEBUG
+# 로깅 설정
+logging:
+  level:
+    root: INFO
+
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.orm.jpa: ERROR
+    org.springframework.transaction: ERROR
+    org.h2.engine: DEBUG

--- a/src/test/java/com/test/learningtx/lock/optimistic/RetryLogicTest.java
+++ b/src/test/java/com/test/learningtx/lock/optimistic/RetryLogicTest.java
@@ -1,0 +1,154 @@
+package com.test.learningtx.lock.optimistic;
+
+import com.test.learningtx.entity.OptimisticAccount;
+import com.test.learningtx.repository.OptimisticAccountRepository;
+import com.test.learningtx.service.OptimisticLockService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class RetryLogicTest {
+
+    @Autowired
+    private OptimisticAccountRepository repository;
+
+    @Autowired
+    private OptimisticLockService optimisticService;
+
+    private OptimisticAccount testAccount;
+    private final Executor executor = Executors.newFixedThreadPool(10);
+
+    @BeforeEach
+    void setup() {
+        testAccount = OptimisticAccount.builder()
+                .name("재시도 테스트")
+                .balance(BigDecimal.valueOf(10000))
+                .build();
+
+        testAccount = repository.saveAndFlush(testAccount);
+
+        System.out.printf("테스트 계좌 생성: %s%n", testAccount);
+    }
+
+    @Test
+    void testWithoutRetry_ShouldFail() {
+        int threadCnt = 5;
+        BigDecimal withdrawAmount = BigDecimal.valueOf(100);
+
+        List<CompletableFuture<String>> tasks = new ArrayList<>();
+        for (int i=0; i<threadCnt; i++) {
+            int idx = i;
+
+            CompletableFuture<String> withdrawTask = CompletableFuture.supplyAsync(() -> {
+                try {
+                    System.out.printf("스레드 %d 시작 (재시도x)%n", idx);
+                    optimisticService.withdrawNoRetry(testAccount.getId(), withdrawAmount);
+                    System.out.printf("스레드 %d 성공%n", idx);
+                    return "success";
+                } catch (OptimisticLockingFailureException e) {
+                    System.out.printf("스레드 %d OptimisticLock 실패%n", idx);
+                    return "OPTIMISTIC_FAILURE";
+                } catch (Exception e) {
+                    System.out.printf("스레드 %d 기타 오류. %s%n", idx, e.getMessage());
+                    return "OTHER_FAILURE";
+                }
+
+            }, executor);
+
+            tasks.add(withdrawTask);
+        }
+
+        // 모든 Future 완료 대기 및 결과 수집
+        List<String> results = tasks.stream().map(CompletableFuture::join).toList();
+
+        // 결과 분석
+        long successCount = results.stream().filter("SUCCESS"::equals).count();
+        long optimisticFailures = results.stream().filter("OPTIMISTIC_FAILURE"::equals).count();
+        long otherFailures = results.stream().filter("OTHER_FAILURE"::equals).count();
+
+        System.out.printf("\n=== 결과 분석 ===%n");
+        System.out.printf("성공: %d건%n", successCount);
+        System.out.printf("낙관적 락 실패: %d건%n", optimisticFailures);
+        System.out.printf("기타 실패: %d건%n", otherFailures);
+
+        // 동시 접근에서 낙관적 락 실패가 발생했을 것으로 예상
+        assertTrue(optimisticFailures > 0, "재시도 없이는 낙관적 락 실패가 발생해야 합니다");
+    }
+
+    @Test
+    void testWithRetry_ShouldSucceed() {
+        int threadCnt = 5;
+        BigDecimal withdrawAmount = BigDecimal.valueOf(100);
+
+        List<CompletableFuture<Boolean>> tasks = new ArrayList<>();
+        for (int i=0; i<threadCnt; i++) {
+            int idx = i;
+
+            CompletableFuture<Boolean> withdrawTask = CompletableFuture.supplyAsync(() -> {
+                try {
+                    // 🔑 핵심 1: 스레드별로 다른 시작 시간
+                    /*낙관적 락의 한계:
+                    동시성이 높으면 → 충돌 많음 → 재시도 많음 → 성능 저하
+                    동시성을 줄이면 → 충돌 적음 → 하지만 순차 실행과 비슷*/
+                    int staggerDelay = idx * 500; // 0ms, 500ms, 1000ms, 1500ms, 2000ms
+                    if (staggerDelay > 0) {
+                        Thread.sleep(staggerDelay);
+                        System.out.printf("스레드 %d: %dms 지연 후 시작%n", idx, staggerDelay);
+                    } else {
+                        System.out.printf("스레드 %d: 즉시 시작%n", idx);
+                    }
+                    System.out.printf("스레드 %d 시작 (재시도 o)%n", idx);
+                    optimisticService.wirhdrawWithRetry(testAccount.getId(), withdrawAmount);
+                    System.out.printf("스레드 %d 성공%n", idx);
+                    return true;
+                } catch (Exception e) {
+                    System.out.printf("스레드 %d 최종 실패. %s%n", idx, e.getMessage());
+                    return false;
+                }
+
+            }, executor);
+
+            tasks.add(withdrawTask);
+        }
+
+        // 모든 Future 완료 대기 및 결과 수집
+        List<Boolean> results = tasks.stream()
+                .map(CompletableFuture::join)
+                .toList();
+
+        // 결과 분석
+        long successCount = results.stream().filter(Boolean::booleanValue).count();
+        long failureCount = results.stream().filter(result -> !result).count();
+
+        System.out.printf("\n=== 결과 분석 ===%n");
+        System.out.printf("성공: %d건, 실패: %d건%n", successCount, failureCount);
+
+        // 재시도 덕분에 모든 거래가 성공했을 것으로 예상
+        assertEquals(threadCnt, successCount, "재시도 로직으로 모든 거래가 성공해야 합니다");
+        assertEquals(0, failureCount, "재시도 로직으로 실패가 없어야 합니다");
+
+        // 최종 잔액 확인
+        OptimisticAccount finalAccount = repository.findById(testAccount.getId()).orElseThrow();
+        BigDecimal expectedBalance = BigDecimal.valueOf(10000 - (100 * threadCnt));
+        assertEquals(expectedBalance, finalAccount.getBalance());
+
+        System.out.printf("최종 계좌 상태: %s%n", finalAccount);
+    }
+
+
+}

--- a/src/test/java/com/test/learningtx/lock/optimistic/VersionBasicTest.java
+++ b/src/test/java/com/test/learningtx/lock/optimistic/VersionBasicTest.java
@@ -1,0 +1,165 @@
+package com.test.learningtx.lock.optimistic;
+
+import com.test.learningtx.entity.OptimisticAccount;
+import com.test.learningtx.repository.OptimisticAccountRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class VersionBasicTest {
+
+    @Autowired
+    private OptimisticAccountRepository repository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("[1] @Version 기본 동작 테스트")
+    @Transactional
+    void testVersionBasicBehavior() {
+        OptimisticAccount account = OptimisticAccount.builder()
+                .name("테스트 사용자")
+                .balance(BigDecimal.valueOf(1000))
+                .build();
+
+        System.out.printf("저장 전: %s%n", account);
+
+        OptimisticAccount saved = repository.saveAndFlush(account);
+
+        // version이 0으로 시작하는지 확인
+        assertEquals(0L, saved.getVersion(), "처음 저장 시 version은 0이어야 합니다");
+
+        // 3. 첫 번째 수정
+        saved.deposit(BigDecimal.valueOf(500));
+        OptimisticAccount updated1 = repository.saveAndFlush(saved);
+        System.out.printf("첫 번째 수정 후: %s%n", updated1);
+
+        // version이 1로 증가했는지 확인
+        assertEquals(1L, updated1.getVersion(), "첫 번째 수정 후 version은 1이어야 합니다");
+        assertEquals(BigDecimal.valueOf(1500), updated1.getBalance());
+
+        // 4. 두 번째 수정
+        updated1.withdraw(BigDecimal.valueOf(200));
+        OptimisticAccount updated2 = repository.saveAndFlush(updated1);
+        System.out.printf("두 번째 수정 후: %s%n", updated2);
+
+        // version이 2로 증가했는지 확인
+        assertEquals(2L, updated2.getVersion(), "두 번째 수정 후 version은 2여야 합니다");
+        assertEquals(BigDecimal.valueOf(1300), updated2.getBalance());
+    }
+
+    /**
+     * 테스트 2: 낙관적 락 충돌 시뮬레이션
+     *
+     * 👤 사용자A: 계좌 조회 (잔액: 1000, version: 5)
+     * 👤 사용자B: 계좌 조회 (잔액: 1000, version: 5)
+     *
+     * 👤 사용자A: 100원 출금 처리
+     * 💾 UPDATE ... SET version=6 WHERE version=5 ✅ 성공!
+     *
+     * 👤 사용자B: 200원 출금 처리
+     * 💾 UPDATE ... SET version=6 WHERE version=5 ❌ 실패!
+     * 🚨 OptimisticLockingFailureException 발생!
+     */
+    @Test
+    void testOptimisticLockException() {
+        System.out.println("=== 낙관적 락 충돌 테스트 ===");
+
+        // 1. 계좌 생성
+        OptimisticAccount account = OptimisticAccount.builder()
+                .name("충돌 테스트")
+                .balance(BigDecimal.valueOf(1000))
+                .build();
+        account = repository.save(account);
+
+        System.out.printf("초기 계좌: %s%n", account);
+
+        // 2. 두 개의 트랜잭션에서 동일한 엔티티 조회
+        OptimisticAccount account1 = repository.findById(account.getId()).orElseThrow();
+        OptimisticAccount account2 = repository.findById(account.getId()).orElseThrow();
+
+        System.out.printf("첫 번째 조회: %s%n", account1);
+        System.out.printf("두 번째 조회: %s%n", account2);
+
+        // 둘 다 같은 version을 가지고 있는지 확인
+        assertEquals(account1.getVersion(), account2.getVersion());
+
+        // 3. 첫 번째 트랜잭션에서 수정 및 저장 (성공)
+        account1.deposit(BigDecimal.valueOf(100));
+        OptimisticAccount saved1 = repository.save(account1);
+        System.out.printf("첫 번째 수정 성공: %s%n", saved1);
+
+        // version이 증가했는지 확인
+        assertEquals(1L, saved1.getVersion());
+
+        // 4. 두 번째 트랜잭션에서 수정 시도 (실패 예상)
+        account2.withdraw(BigDecimal.valueOf(200));
+
+        System.out.println("두 번째 수정 시도... OptimisticLockingFailureException 예상");
+
+        assertThrows(OptimisticLockingFailureException.class, () -> {
+            repository.save(account2);
+        }, "version 충돌 시 OptimisticLockingFailureException이 발생해야 합니다");
+
+        System.out.println("예상대로 OptimisticLockingFailureException 발생!");
+
+        // 5. 최종 상태 확인
+        OptimisticAccount finalAccount = repository.findById(account.getId()).orElseThrow();
+        System.out.printf("최종 계좌 상태: %s%n", finalAccount);
+
+        // 첫 번째 트랜잭션의 변경사항만 반영되어야 함
+        assertEquals(BigDecimal.valueOf(1100), finalAccount.getBalance());
+        assertEquals(1L, finalAccount.getVersion());
+    }
+
+    /**
+     * 테스트 3: SQL 로그 확인용 테스트
+     */
+    @Test
+    @Transactional
+    void testSqlLogs() {
+        System.out.println("=== SQL 로그 확인 테스트 ===");
+
+        OptimisticAccount account = OptimisticAccount.builder()
+                .name("SQL 테스트")
+                .balance(BigDecimal.valueOf(1000))
+                .build();
+
+        // save()만 사용하면 Hibernate는 실제 DB에 쿼리를 보내지 않고 영속성 컨텍스트에만 저장
+        // flush()까지 호출해서 바로 DB에 반영
+        System.out.println("INSERT SQL 확인:");
+        repository.saveAndFlush(account);
+
+        // save() 후 1차 캐시(영속성 컨텍스트)에 이미 있어서 Hibernate가 SELECT를 안함.
+        // 영속성 컨텍스트 clear로 1차 캐시 비워야 SELECT 다시 실행함
+        entityManager.clear();
+
+        System.out.println("SELECT SQL 확인:");
+        OptimisticAccount found = repository.findById(account.getId()).orElseThrow();
+
+        // 낙관적 락(Optimistic Locking)을 쓸 경우, version 필드가 바뀌어야 UPDATE가 발생
+        System.out.println("UPDATE SQL 확인 (version WHERE 조건 주목!):");
+        found.deposit(BigDecimal.valueOf(100));
+        repository.saveAndFlush(found);
+
+        System.out.println("테스트 완료 - 콘솔에서 SQL 로그를 확인해보세요!");
+    }
+
+
+}


### PR DESCRIPTION
- @Version 어노테이션 기반 낙관적 락 테스트
- EntityManager.refresh()로 1차 캐시 문제 해결
- 시작 시점 분산을 통한 충돌 완화 전략
- OptimisticLockingFailureException 재시도 로직

[chore] 기본 설정 오류 수정
- port, profiles